### PR TITLE
boot0img: Add an option for embedding DTB to legacy images

### DIFF
--- a/tools/boot0img.c
+++ b/tools/boot0img.c
@@ -531,7 +531,7 @@ int main(int argc, char **argv)
 
 	if (dram_fname) {
 		if (!quiet)
-			fprintf(stderr, "DRAM  : %s", dram_fname);
+			fprintf(stderr, "DRAM  : %s: ", dram_fname);
 
 		if (!strncmp(dram_fname, "trampoline64:", 13) ||
 		    !strncmp(dram_fname, "trampoline32:", 13)) {

--- a/tools/boot0img.c
+++ b/tools/boot0img.c
@@ -277,7 +277,7 @@ static void *realloc_zero(void *ptr, ssize_t *sizeptr, ssize_t newsize)
 	ret = realloc(ptr, newsize);
 
 	if (newsize > *sizeptr)
-		memset((char*)ptr + *sizeptr, 0, newsize - *sizeptr);
+		memset((char*)ret + *sizeptr, 0, newsize - *sizeptr);
 
 	*sizeptr = newsize;
 


### PR DESCRIPTION
This change allows building bootable legacy images without using [sunxi-pack-tools](https://github.com/longsleep/sunxi-pack-tools/).

Tested with following command line:

```
./boot0img -B blobs/boot0.bin -u u-boot-pine64/u-boot.bin -e -F pine64.dtb -s blobs/scp.bin \ 
 -d arm-trusted-firmware/build/sun50iw1p1/debug/bl31.bin -o u-boot-for-flashing.bin
```

where `u-boot-pine64/u-boot.bin` is a result of compiling [legacy u-boot](https://github.com/longsleep/u-boot-pine64) without any changes.

For the reference, setting u-boot size/DTB offset in header is needed due to [this code](https://github.com/longsleep/u-boot-pine64/blob/pine64-hacks/common/board_f.c#L356-L368) in u-boot.
